### PR TITLE
Fix validate script to capture pipestatus

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -27,4 +27,7 @@ find . -type f -name $k -print0 | while IFS= read -r -d $'\0' file;
   do
     echo "INFO - Validating kustomization ${file/%$k}"
     kustomize build "${file/%$k}" | kubeval --ignore-missing-schemas
+    if [[ ${PIPESTATUS[0]} != 0 ]]; then
+      exit 1
+    fi
 done


### PR DESCRIPTION
when `kustomize build` gets error, kubeval recognizes the output as empty YAML and gives PASS. use `PIPESTATUS` to properly capture exit status of piped command as workaround.

things like that could happen:
```
$ kustomize build blabla.yaml | kubeval
Error: error creating new loader with git: url lacks orgRepo: blabla.yaml, dir: evalsymlink failure on 'blabla.yaml' : lstat /home/raphael/repos/flux2-kustomize-helm-example/blabla.yaml: no such file or directory, get: invalid source string: blabla.yaml
PASS - stdin contains an empty YAML document
```