### PR TITLE
Validate Flux custom resource in CI

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -14,7 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script is meant to be run locally and in CI to validate the Kubernetes
+# manifests (including Flux custom resources) before changes are merged into
+# the branch synced by Flux in-cluster.
+
+# Prerequisites
+# - yq v4.6
+# - kustomize v3.9
+# - kubeval v0.15
+
 set -o errexit
+
+echo "INFO - Downloading Flux OpenAPI schemas"
+mkdir -p /tmp/flux-crd-schemas/master-standalone-strict
+curl -sL https://github.com/fluxcd/flux2/releases/latest/download/crd-schemas.tar.gz | tar zxf - -C /tmp/flux-crd-schemas/master-standalone-strict
 
 # mirror kustomize-controller build options
 kustomize_flags="--enable_kyaml=false --allow_id_changes=false --load_restrictor=LoadRestrictionsNone"
@@ -26,10 +39,20 @@ find . -type f -name '*.yaml' -print0 | while IFS= read -r -d $'\0' file;
     yq e 'true' "$file" > /dev/null
 done
 
+echo "INFO - Validating clusters"
+find ./clusters -type f -name '*.yaml' -print0 | while IFS= read -r -d $'\0' file;
+  do
+    kubeval ${file} --strict --additional-schema-locations=file:///tmp/flux-crd-schemas
+    if [[ ${PIPESTATUS[0]} != 0 ]]; then
+      exit 1
+    fi
+done
+
+echo "INFO - Validating kustomize overlays"
 find . -type f -name $kustomize_config -print0 | while IFS= read -r -d $'\0' file;
   do
     echo "INFO - Validating kustomization ${file/%$kustomize_config}"
-    kustomize build "${file/%$kustomize_config}" $kustomize_flags | kubeval --ignore-missing-schemas
+    kustomize build "${file/%$kustomize_config}" $kustomize_flags | kubeval --strict --additional-schema-locations=file:///tmp/flux-crd-schemas
     if [[ ${PIPESTATUS[0]} != 0 ]]; then
       exit 1
     fi


### PR DESCRIPTION
This PR extends the validation script to include the Flux custom resources.

The script downloads the latest OpenAPI schemas from flux2 release page to `/tmp/flux-crd-schemas/master-standalone-strict` and sets the additional-schema-locations in kubeval.