### PR TITLE
Run validate manifests action as non-root user

### DIFF
--- a/.github/actions/tools/Dockerfile
+++ b/.github/actions/tools/Dockerfile
@@ -2,5 +2,5 @@ FROM stefanprodan/alpine-base:latest
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-
+USER 1001
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
The validate manifests action docker container currently runs as root which goes against security best practices for containers. User 1001 provides the necessary elevated privileges to run what's needed by github/azure/etc while not running the container directly as root. This PR would resolve [Issue 34](https://github.com/fluxcd/flux2-kustomize-helm-example/issues/34)