### PR TITLE
Update validate.sh to match flux2-multi-tenancy

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -34,10 +34,6 @@ echo "INFO - Downloading Flux OpenAPI schemas"
 mkdir -p /tmp/flux-crd-schemas/master-standalone-strict
 curl -sL https://github.com/fluxcd/flux2/releases/latest/download/crd-schemas.tar.gz | tar zxf - -C /tmp/flux-crd-schemas/master-standalone-strict
 
-# mirror kustomize-controller build options
-kustomize_flags="--load-restrictor=LoadRestrictionsNone --reorder=legacy"
-kustomize_config="kustomization.yaml"
-
 find . -type f -name '*.yaml' -print0 | while IFS= read -r -d $'\0' file;
   do
     echo "INFO - Validating $file"
@@ -45,7 +41,7 @@ find . -type f -name '*.yaml' -print0 | while IFS= read -r -d $'\0' file;
 done
 
 echo "INFO - Validating clusters"
-find ./clusters -type f -name '*.yaml' -maxdepth 1 -print0 | while IFS= read -r -d $'\0' file;
+find ./clusters -maxdepth 2 -type f -name '*.yaml' -print0 | while IFS= read -r -d $'\0' file;
   do
     kubeval ${file} --strict --ignore-missing-schemas --additional-schema-locations=file:///tmp/flux-crd-schemas
     if [[ ${PIPESTATUS[0]} != 0 ]]; then
@@ -53,11 +49,16 @@ find ./clusters -type f -name '*.yaml' -maxdepth 1 -print0 | while IFS= read -r 
     fi
 done
 
+# mirror kustomize-controller build options
+kustomize_flags="--load-restrictor=LoadRestrictionsNone --reorder=legacy"
+kustomize_config="kustomization.yaml"
+
 echo "INFO - Validating kustomize overlays"
 find . -type f -name $kustomize_config -print0 | while IFS= read -r -d $'\0' file;
   do
     echo "INFO - Validating kustomization ${file/%$kustomize_config}"
-    kustomize build "${file/%$kustomize_config}" $kustomize_flags | kubeval --ignore-missing-schemas --strict --additional-schema-locations=file:///tmp/flux-crd-schemas
+    kustomize build "${file/%$kustomize_config}" $kustomize_flags | \
+      kubeval --ignore-missing-schemas --strict --additional-schema-locations=file:///tmp/flux-crd-schemas
     if [[ ${PIPESTATUS[0]} != 0 ]]; then
       exit 1
     fi


### PR DESCRIPTION
Update validate.sh to match https://github.com/fluxcd/flux2-multi-tenancy/commit/0ca0c1ddeb171ddfad55678951e59e8f73dd99f9

I think these files should match. I compared them carefully and found that `maxdepth 2` was changed from `maxdepth 1` in that commit

The position of the argument was updated to conform with what `find` on BSD/Mac machines expects. I don't think it makes a difference in other contexts. However the `maxdepth` value was also updated from `1` to `2` without much discussion. I think it makes as much sense to have the value set `2` here as it has been there. 👍 

I updated this file here so that it matches the newer version from https://github.com/fluxcd/flux2-multi-tenancy/pull/35