### PR TITLE
Make entrypoint.sh for flux test.yaml action match

### DIFF
--- a/.github/actions/tools/entrypoint.sh
+++ b/.github/actions/tools/entrypoint.sh
@@ -4,26 +4,24 @@ set -eu
 
 YQ_VERSION="v4.6.1"
 KUSTOMIZE_VERSION="4.1.3"
-KUBEVAL_VERSION="0.15.0"
+KUBEVAL_VERSION="v0.16.1"
 
 mkdir -p $GITHUB_WORKSPACE/bin
+cd $GITHUB_WORKSPACE/bin
 
 curl -sL https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -o yq
 
-cp ./yq $GITHUB_WORKSPACE/bin
 chmod +x $GITHUB_WORKSPACE/bin/yq
 
 kustomize_url=https://github.com/kubernetes-sigs/kustomize/releases/download && \
 curl -sL ${kustomize_url}/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz | \
 tar xz
 
-cp ./kustomize $GITHUB_WORKSPACE/bin
 chmod +x $GITHUB_WORKSPACE/bin/kustomize
 
 curl -sL https://github.com/instrumenta/kubeval/releases/download/${KUBEVAL_VERSION}/kubeval-linux-amd64.tar.gz | \
 tar xz
 
-cp ./kubeval $GITHUB_WORKSPACE/bin
 chmod +x $GITHUB_WORKSPACE/bin/kubeval
 
 echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH


### PR DESCRIPTION
Should match the version in `fluxcd/flux2-multi-tenancy`

The latest version right now is at:
https://github.com/fluxcd/flux2-multi-tenancy/blob/1705a2ce46d8970b65ca764097cb7b18048926d4/.github/actions/tools/entrypoint.sh