### PR TITLE
Add explicit namespace to work with SSA

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: podinfo
+  namespace: podinfo
 spec:
   chart:
     spec:
@@ -171,6 +172,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: HelmRepository
 metadata:
   name: podinfo
+  namespace: flux-system
 spec:
   interval: 5m
   url: https://stefanprodan.github.io/podinfo
@@ -179,6 +181,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: HelmRepository
 metadata:
   name: bitnami
+  namespace: flux-system
 spec:
   interval: 30m
   url: https://charts.bitnami.com/bitnami
@@ -409,6 +412,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: redis
+  namespace: redis
 spec:
   # content omitted for brevity
   values:

--- a/infrastructure/nginx/release.yaml
+++ b/infrastructure/nginx/release.yaml
@@ -2,6 +2,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: nginx
+  namespace: nginx
 spec:
   releaseName: nginx-ingress-controller
   chart:

--- a/infrastructure/redis/release.yaml
+++ b/infrastructure/redis/release.yaml
@@ -2,6 +2,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: redis
+  namespace: redis
 spec:
   releaseName: redis
   chart:

--- a/infrastructure/sources/bitnami.yaml
+++ b/infrastructure/sources/bitnami.yaml
@@ -2,6 +2,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: HelmRepository
 metadata:
   name: bitnami
+  namespace: flux-system
 spec:
   interval: 30m
   url: https://charts.bitnami.com/bitnami

--- a/infrastructure/sources/podinfo.yaml
+++ b/infrastructure/sources/podinfo.yaml
@@ -2,6 +2,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: HelmRepository
 metadata:
   name: podinfo
+  namespace: flux-system
 spec:
   interval: 5m
   url: https://stefanprodan.github.io/podinfo


### PR DESCRIPTION
Since SSA requires explicit namespace, the manifests result in error
`namespace not specified`.
Update the manifests with explicit namespace to work with the latest
flux.