### PR TITLE
Revert (upgrade) Source API to v1beta2

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Infrastructure:
 In **infrastructure/sources/** dir we have the Helm repositories definitions:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -175,7 +175,7 @@ spec:
   interval: 5m
   url: https://stefanprodan.github.io/podinfo
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
   name: bitnami

--- a/infrastructure/sources/bitnami.yaml
+++ b/infrastructure/sources/bitnami.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
   name: bitnami

--- a/infrastructure/sources/podinfo.yaml
+++ b/infrastructure/sources/podinfo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
   name: podinfo


### PR DESCRIPTION
This reverts commit 3395ffb030e38c8693896ad9d61ed1c4936e5086 and returns the state of this repo to match 68b5c87

Following up on:

* https://github.com/fluxcd/flux2-kustomize-helm-example/issues/58