### PR TITLE
Enable automated upgrades for Bitnami charts

### DIFF
--- a/apps/base/podinfo/release.yaml
+++ b/apps/base/podinfo/release.yaml
@@ -19,7 +19,7 @@ spec:
   # Default values
   # https://github.com/stefanprodan/podinfo/blob/master/charts/podinfo/values.yaml
   values:
-    cache: redis-master.redis:6379
+    cache: tcp://redis-master.redis:6379
     ingress:
       enabled: true
       annotations:

--- a/infrastructure/nginx/release.yaml
+++ b/infrastructure/nginx/release.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: bitnami
         namespace: flux-system
-      version: "9.1.11"
+      version: "9.x"
   interval: 1h0m0s
   install:
     remediation:

--- a/infrastructure/redis/release.yaml
+++ b/infrastructure/redis/release.yaml
@@ -11,7 +11,7 @@ spec:
         kind: HelmRepository
         name: bitnami
         namespace: flux-system
-      version: "11.3.4"
+      version: "16.x"
   interval: 1h0m0s
   install:
     remediation:


### PR DESCRIPTION
Automate Flux HelmReleases to upgrade to the latest minor version for:
- `bitnami/nginx-ingress-controller` 9.x
- `bitnami/redis` 16.x

We can't pin chart versions since Binami has enable retention https://github.com/bitnami/charts/issues/10539