### PR TITLE
Ensure that validate.sh fails when `find` fails

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -29,6 +29,7 @@
 # - kubeconform v0.4.12
 
 set -o errexit
+set -o pipefail
 
 echo "INFO - Downloading Flux OpenAPI schemas"
 mkdir -p /tmp/flux-crd-schemas/master-standalone-strict


### PR DESCRIPTION
When the producing command in a pipe fails, a script does not fail, even with `errexit`:

```
[...]
INFO - Validating clusters
find: './clusters': No such file or directory
INFO - Validating kustomize overlays
[...]
$ echo $?
0
```

With this change:

```
INFO - Validating clusters
find: './clusters': No such file or directory
$ echo $?
1
```

Signed-off-by: Philipp Riederer <priederer@genesiscloud.com>