### PR TITLE
Use helm/kind-action for e2e testing

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -17,9 +17,10 @@ jobs:
       - name: Setup Flux
         uses: fluxcd/flux2/action@main
       - name: Setup Kubernetes
-        uses: engineerd/setup-kind@v0.5.0
+        uses: helm/kind-action@v1.5.0
         with:
-          version: "v0.17.0"
+          version: v0.17.0
+          cluster_name: flux
       - name: Install Flux in Kubernetes Kind
         run: flux install
       - name: Setup cluster reconciliation


### PR DESCRIPTION
Replace `engineerd/setup-kind` which is no longer maintained with `helm/kind-action`.