### PR TITLE
Update APIs to v1 (Flux v2.0.0-rc.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ spec:
 In **clusters/production/infrastructure.yaml** we replace the Let's Encrypt server value to point to the production API:
 
 ```yaml
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: infra-configs
@@ -259,7 +259,7 @@ The clusters dir contains the Flux configuration:
 In **clusters/staging/** dir we have the Flux Kustomization definitions, for example:
 
 ```yaml
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: apps

--- a/clusters/production/apps.yaml
+++ b/clusters/production/apps.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: apps

--- a/clusters/production/infrastructure.yaml
+++ b/clusters/production/infrastructure.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: infra-controllers
@@ -15,7 +15,7 @@ spec:
   prune: true
   wait: true
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: infra-configs

--- a/clusters/staging/apps.yaml
+++ b/clusters/staging/apps.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: apps

--- a/clusters/staging/infrastructure.yaml
+++ b/clusters/staging/infrastructure.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: infra-controllers
@@ -15,7 +15,7 @@ spec:
   prune: true
   wait: true
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: infra-configs


### PR DESCRIPTION
This PR update the GitRepository and Kustomization APIs to v1, first introduced in Flux [v2.0.0-rc.1](https://github.com/fluxcd/flux2/releases/tag/v2.0.0-rc.1) .
