### PR TITLE
Use Kustomize patches instead of patchesStrategicMerge

### DIFF
--- a/apps/production/kustomization.yaml
+++ b/apps/production/kustomization.yaml
@@ -2,5 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base/podinfo
-patchesStrategicMerge:
-  - podinfo-values.yaml
+patches:
+  - path: podinfo-values.yaml
+    target:
+      kind: HelmRelease

--- a/apps/staging/kustomization.yaml
+++ b/apps/staging/kustomization.yaml
@@ -3,5 +3,7 @@ kind: Kustomization
 namespace: podinfo
 resources:
   - ../base/podinfo
-patchesStrategicMerge:
-  - podinfo-values.yaml
+patches:
+  - path: podinfo-values.yaml
+    target:
+      kind: HelmRelease


### PR DESCRIPTION
As pointed out by @cer in https://github.com/fluxcd/flux2/discussions/3747#discussioncomment-5886435 `patchesStrategicMerge` has been deprecated in Kustomize v5. 