### PR TITLE
ci: fix ignore-paths when creating git source

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -25,7 +25,7 @@ jobs:
           flux create source git flux-system \
           --url=${{ github.event.repository.html_url }} \
           --branch=${GITHUB_REF#refs/heads/} \
-          --ignore-paths="./clusters/**/flux-system/"
+          --ignore-paths="clusters/staging/flux-system/"
           flux create kustomization flux-system \
           --source=flux-system \
           --path=./clusters/staging

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -25,7 +25,7 @@ jobs:
           flux create source git flux-system \
           --url=${{ github.event.repository.html_url }} \
           --branch=${GITHUB_REF#refs/heads/} \
-          --ignore-paths="clusters/staging/flux-system/"
+          --ignore-paths="clusters/**/flux-system/"
           flux create kustomization flux-system \
           --source=flux-system \
           --path=./clusters/staging


### PR DESCRIPTION
As stated in #56, the e2e step will fail if flux has pushed the manifests to the repo, because the path is not ignored properly.

See my comment in https://github.com/fluxcd/flux2-kustomize-helm-example/issues/56#issuecomment-1637028238

I have tested the changes in https://github.com/darioblanco/gitops and it works now.