### PR TITLE
fix validate.sh

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -42,7 +42,7 @@ curl -sL https://github.com/fluxcd/flux2/releases/latest/download/crd-schemas.ta
 find . -type f -name '*.yaml' -print0 | while IFS= read -r -d $'\0' file;
   do
     echo "INFO - Validating $file"
-    yq e 'true' "$file" > /dev/null
+       cat $file | yq > /dev/null
 done
 
 echo "INFO - Validating clusters"


### PR DESCRIPTION
# Whats the issue?

Validation scripts throws an error when trying o run `scripts/valdidate.sh` locally

# How can I reproduce this issue?

Make a template from this repo install `yq` version 3.2.2 and run `scripts/validate.sh`

# How did I test?

Apply patch and run `scripts/vaidate.sh`


# Comment on fix

Fix adds dependency on the tool `cat` being available on the system.

# Environment
```bash
 yq --version
yq 3.2.2
```

```
❯ cat /etc/os-release
ANSI_COLOR="1;34"
BUG_REPORT_URL="https://github.com/NixOS/nixpkgs/issues"
BUILD_ID="24.11.20240917.658e722"
DOCUMENTATION_URL="https://nixos.org/learn.html"
HOME_URL="https://nixos.org/"
ID=nixos
IMAGE_ID=""
IMAGE_VERSION=""
LOGO="nix-snowflake"
NAME=NixOS
PRETTY_NAME="NixOS 24.11 (Vicuna)"
SUPPORT_URL="https://nixos.org/community.html"
VERSION="24.11 (Vicuna)"
VERSION_CODENAME=vicuna
VERSION_ID="24.11"
```