### PR TITLE
Update cert-manager CRD installation config

### DIFF
--- a/infrastructure/controllers/cert-manager.yaml
+++ b/infrastructure/controllers/cert-manager.yaml
@@ -34,4 +34,4 @@ spec:
   values:
     crds:
       enabled: true
-      keep: true
+      keep: false

--- a/infrastructure/controllers/cert-manager.yaml
+++ b/infrastructure/controllers/cert-manager.yaml
@@ -32,4 +32,6 @@ spec:
         namespace: cert-manager
       interval: 12h
   values:
-    installCRDs: true
+    crds:
+      enabled: true
+      keep: true


### PR DESCRIPTION
The `installCRDs` configuration on the helm chart is deprecated in favor of `crds.enabled` and `crds.keep`. https://artifacthub.io/packages/helm/cert-manager/cert-manager#installcrds-~-bool