### PR TITLE
Refactor validation script

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,28 +1,17 @@
 #!/usr/bin/env bash
 
+# Copyright 2023-2026 The Flux authors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # This script downloads the Flux OpenAPI schemas, then it validates the
 # Flux custom resources and the kustomize overlays using kubeconform.
 # This script is meant to be run locally and in CI before the changes
 # are merged on the main branch that's synced by Flux.
 
-# Copyright 2023 The Flux authors. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 # Prerequisites
-# - yq v4.48
-# - kustomize v5.7
-# - kubeconform v0.7
+# - yq >= 4.50
+# - kustomize >= 5.8
+# - kubeconform >= 0.7
 
 set -o errexit
 set -o pipefail
@@ -35,32 +24,183 @@ kustomize_config="kustomization.yaml"
 kubeconform_flags=("-skip=Secret")
 kubeconform_config=("-strict" "-ignore-missing-schemas" "-schema-location" "default" "-schema-location" "/tmp/flux-crd-schemas" "-verbose")
 
-echo "INFO - Downloading Flux OpenAPI schemas"
-mkdir -p /tmp/flux-crd-schemas/master-standalone-strict
-curl -sL https://github.com/fluxcd/flux2/releases/latest/download/crd-schemas.tar.gz | tar zxf - -C /tmp/flux-crd-schemas/master-standalone-strict
+# root directory to validate
+root_dir="."
 
-find . -type f -name '*.yaml' -print0 | while IFS= read -r -d $'\0' file;
-  do
-    echo "INFO - Validating $file"
-    yq e 'true' "$file" > /dev/null
-done
+# directories to exclude from validation
+exclude_dirs=()
 
-echo "INFO - Validating clusters"
-find ./clusters -maxdepth 2 -type f -name '*.yaml' -print0 | while IFS= read -r -d $'\0' file;
-  do
-    kubeconform "${kubeconform_flags[@]}" "${kubeconform_config[@]}" "${file}"
-    if [[ ${PIPESTATUS[0]} != 0 ]]; then
-      exit 1
+# directories auto-detected as non-Kubernetes (terraform, helm charts)
+declare -a auto_skip_dirs=()
+
+# directories that are kustomize overlays
+declare -a kustomize_dirs=()
+
+usage() {
+  echo "Usage: $0 [-d <dir>] [-e <dir>]... [-h]"
+  echo ""
+  echo "Validate Flux custom resources and kustomize overlays using kubeconform."
+  echo ""
+  echo "Options:"
+  echo "  -d, --dir <dir>      Root directory to validate (default: current directory)"
+  echo "  -e, --exclude <dir>  Directory to exclude from validation (can be repeated)"
+  echo "  -h, --help           Show this help message"
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -d|--dir)
+        if [[ -z "${2:-}" ]]; then
+          echo "ERROR - --dir requires a directory argument" >&2
+          exit 1
+        fi
+        root_dir="${2%/}"
+        shift 2
+        ;;
+      -e|--exclude)
+        if [[ -z "${2:-}" ]]; then
+          echo "ERROR - --exclude requires a directory argument" >&2
+          exit 1
+        fi
+        exclude_dirs+=("./${2#./}")
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "ERROR - Unknown argument: $1" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+  done
+}
+
+check_prerequisites() {
+  local missing=0
+  for cmd in yq kustomize kubeconform curl; do
+    if ! command -v "$cmd" &> /dev/null; then
+      echo "ERROR - $cmd is not installed" >&2
+      missing=1
     fi
-done
+  done
+  if [[ $missing -ne 0 ]]; then
+    exit 1
+  fi
+}
 
-echo "INFO - Validating kustomize overlays"
-find . -type f -name $kustomize_config -print0 | while IFS= read -r -d $'\0' file;
-  do
-    echo "INFO - Validating kustomization ${file/%$kustomize_config}"
+download_schemas() {
+  echo "INFO - Downloading Flux OpenAPI schemas"
+  mkdir -p /tmp/flux-crd-schemas/master-standalone-strict
+  curl -sL https://github.com/controlplaneio-fluxcd/flux-operator/releases/latest/download/crd-schemas.tar.gz | tar zxf - -C /tmp/flux-crd-schemas/master-standalone-strict
+  curl -sL https://github.com/fluxcd/flux2/releases/latest/download/crd-schemas.tar.gz | tar zxf - -C /tmp/flux-crd-schemas/master-standalone-strict
+}
+
+# Normalize a path by stripping leading "./" for consistent comparisons
+normalize_path() {
+  local p="${1#./}"
+  echo "${p%/}"
+}
+
+# Check if a path is under a user-excluded, auto-skipped, or kustomize directory
+is_excluded_dir() {
+  local path
+  path="$(normalize_path "$1")"
+  for dir in "${exclude_dirs[@]}"; do
+    local d
+    d="$(normalize_path "$dir")"
+    if [[ "$path" == "$d"/* || "$path" == "$d" ]]; then
+      return 0
+    fi
+  done
+  for dir in "${auto_skip_dirs[@]}"; do
+    local d
+    d="$(normalize_path "$dir")"
+    if [[ "$path" == "$d"/* || "$path" == "$d" ]]; then
+      return 0
+    fi
+  done
+  for dir in "${kustomize_dirs[@]}"; do
+    local d
+    d="$(normalize_path "$dir")"
+    if [[ "$path" == "$d"/* || "$path" == "$d" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Check if a path is under a user-excluded or auto-skipped directory (but not kustomize dirs)
+is_non_kustomize_excluded_dir() {
+  local path
+  path="$(normalize_path "$1")"
+  for dir in "${exclude_dirs[@]}" "${auto_skip_dirs[@]}"; do
+    local d
+    d="$(normalize_path "$dir")"
+    if [[ "$path" == "$d"/* || "$path" == "$d" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Detect directories containing Terraform files, Helm charts, or kustomize overlays
+detect_excluded_dirs() {
+  while IFS= read -r -d $'\0' file; do
+    auto_skip_dirs+=("$(dirname "$file")")
+  done < <(find "$root_dir" -path '*/.*' -prune -o -type f \( -name '*.tf' -o -name 'Chart.yaml' \) -print0)
+
+  while IFS= read -r -d $'\0' file; do
+    kustomize_dirs+=("$(dirname "$file")")
+  done < <(find "$root_dir" -path '*/.*' -prune -o -type f -name "$kustomize_config" -print0)
+}
+
+validate_yaml_syntax() {
+  echo "INFO - Validating YAML syntax"
+  while IFS= read -r -d $'\0' file; do
+    dir="$(dirname "$file")"
+    if is_excluded_dir "$dir"; then
+      continue
+    fi
+    yq e 'true' "$file" > /dev/null
+  done < <(find "$root_dir" -path '*/.*' -prune -o -type f -name '*.yaml' -print0)
+}
+
+validate_kubernetes_manifests() {
+  echo "INFO - Validating Kubernetes manifests"
+  while IFS= read -r -d $'\0' file; do
+    dir="$(dirname "$file")"
+    if is_excluded_dir "$dir"; then
+      continue
+    fi
+    kubeconform "${kubeconform_flags[@]}" "${kubeconform_config[@]}" "${file}"
+  done < <(find "$root_dir" -path '*/.*' -prune -o -type f -name '*.yaml' -print0)
+}
+
+validate_kustomize_overlays() {
+  while IFS= read -r -d $'\0' file; do
+    dir="$(dirname "$file")"
+    if is_non_kustomize_excluded_dir "$dir"; then
+      continue
+    fi
+    echo "INFO - Validating kustomize overlay ${file/%$kustomize_config}"
     kustomize build "${file/%$kustomize_config}" "${kustomize_flags[@]}" | \
       kubeconform "${kubeconform_flags[@]}" "${kubeconform_config[@]}"
-    if [[ ${PIPESTATUS[0]} != 0 ]]; then
+    if [[ ${PIPESTATUS[0]} != 0 || ${PIPESTATUS[1]} != 0 ]]; then
       exit 1
     fi
-done
+  done < <(find "$root_dir" -path '*/.*' -prune -o -type f -name "$kustomize_config" -print0)
+}
+
+# Main
+parse_args "$@"
+check_prerequisites
+download_schemas
+detect_excluded_dirs
+validate_yaml_syntax
+validate_kubernetes_manifests
+validate_kustomize_overlays
+echo "INFO - All validations passed"


### PR DESCRIPTION
The validation script should now work no matter the repo structure and its contents.

Improvements:  
 - Added CLI flags: New `-d/--dir `to set root directory and `-e/--exclude` to skip specific directories, replacing the hardcoded paths
- Added prerequisite checks: Verifies yq, kustomize, kubeconform, and curl are installed before running                                                          
- Auto-detection of non-Kubernetes directories: Automatically skips Terraform (`.tf`) and Helm Chart (`Chart.yaml`) directories from validation
- Downloads schemas from both `flux2` and `flux-operator` releases, enabling validation of Flux Operator custom resources
- Broader kubeconform coverage: Validates all Kubernetes YAML files across the repo (excluding kustomize overlays and auto-detected non-K8s dirs), not just  ./clusters with a depth limit of 2
- Hidden directory pruning: All find commands now skip dotfile directories (.github, .sops, etc.)
- Refactored from a flat script into functions
