### PR TITLE
ci: Update schema validation config to use KRM-style

### DIFF
--- a/.fluxschema.yml
+++ b/.fluxschema.yml
@@ -1,10 +1,11 @@
-version: "1"
+apiVersion: schema.plugin.fluxcd.io/v1beta1
+kind: Config
 validate:
-  schema-location:
+  schemaLocation:
     - default
     - https://raw.githubusercontent.com/datreeio/CRDs-catalog/main
-  skip-json-path:
+  skipJSONPath:
     - Secret:/sops
-  skip-missing-schemas: true
+  skipMissingSchemas: true
   verbose: true
   output: text


### PR DESCRIPTION
[flux-schema v0.4.0] updated the schema validation config format, causing a regression for repos using flux-schema the validation action with the old `.fluxschema.yml` format.

These changes update the provided example schema validation config so that the test workflow once again passes.


[flux-schema v0.4.0]: https://github.com/fluxcd/flux-schema/releases/tag/v0.4.0